### PR TITLE
base64.encodestring to base64.encodebytes

### DIFF
--- a/examples/rest_api/utils.py
+++ b/examples/rest_api/utils.py
@@ -79,7 +79,7 @@ def setup_logging() -> None:
 def setup_connection(api_user: str, api_pass: str):
     """Configure the default connection for the application"""
 
-    base64string = base64.encodestring(
+    base64string = base64.encodebytes(
         ('%s:%s' %
          (api_user, api_pass)).encode()).decode().replace('\n', '')
 


### PR DESCRIPTION
please refer to issue https://github.com/NetApp/ontap-rest-python/issues/34
This PR is fixing base64.encodestring() deprecated since Python 3.1.